### PR TITLE
Use curly-bracket notation in factory_bot

### DIFF
--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     association :to_user, factory: :user, strategy: :build
 
     trait :with_read_at do
-      read_at Time.current
+      read_at { Time.current }
     end
 
     factory :read_message, traits: %i(with_read_at)


### PR DESCRIPTION
# Why
Static attributes (without a block) are no longer available in factory_bot 5.

# Refs.
- https://github.com/thoughtbot/factory_bot/blob/master/GETTING_STARTED.md#static-attributes
- https://thoughtbot.com/blog/deprecating-static-attributes-in-factory_bot-4-11
- https://github.com/thoughtbot/factory_bot/blob/master/NEWS.md#500-february-1-2019
- https://github.com/thoughtbot/factory_bot_rails/issues/315#issuecomment-461094106