### PR TITLE
Unify "sqlite3" gem version with it used in "activerecord" gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shiroyagi (1.0.1)
+    shiroyagi (1.1.3)
       rails (>= 5.2.2)
 
 GEM
@@ -153,7 +153,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.8)
@@ -171,7 +171,7 @@ DEPENDENCIES
   pry-byebug
   rspec-rails
   shiroyagi!
-  sqlite3
+  sqlite3 (~> 1.4)
 
 BUNDLED WITH
    1.16.6

--- a/shiroyagi.gemspec
+++ b/shiroyagi.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 5.2.2'
 
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.4'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'factory_bot_rails'
   s.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
#  Why
In activerecord `6.0.3.4` uses sqlite3 `1.4.x`. It needs to unify the versions to run tests.

Warning was:
```
$ bundle _1.16.6_ exec rspec

bundler: failed to load command: rspec
(/Users/machupicchubeta/Repositories/github.com/machupicchubeta/shiroyagi/vendor/bundle/bin/rspec)
LoadError: Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.4), already activated sqlite3-1.3.13. Make sure all dependencies are added to Gemfile.
```

# See also
- https://github.com/rails/rails/blob/v6.0.3.4/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L13